### PR TITLE
Rosetta's latest_release object needs to return an array containing zip/tar urls and sizes as well as version number

### DIFF
--- a/config/wordpress-config/sites/global.wordpress.dev/sandbox-functionality.php
+++ b/config/wordpress-config/sites/global.wordpress.dev/sandbox-functionality.php
@@ -5,6 +5,10 @@ register_theme_directory( ABSPATH . 'wp-content/themes' );
 
 // Load mu-plugins in subdirectories
 define( 'WP_CORE_STABLE_BRANCH', '3.9' );
+define( 'WP_CORE_ZIP_SIZE', '6.4' );
+define( 'WP_CORE_TAR_URL', 'download.tar.gz' );
+define( 'WP_CORE_ZIP_URL', 'download.zip' );
+define( 'WP_CORE_TAR_SIZE', '5.9' );
 require_once( __DIR__ . '/downloads/rosetta-downloads.php' );
 require_once( __DIR__ . '/roles/rosetta-roles.php' );
 require_once( __DIR__ . '/showcase/rosetta-showcase.php' );
@@ -22,7 +26,16 @@ class Rosetta_WordPress {
 
 class Rosetta {
 	public function get_latest_release() {
-		return WP_CORE_STABLE_BRANCH;
+
+		// Expected to be an array containing version, zip_size_mb, targz_url, zip_url, tar_size_mb
+		return array(
+			'version' 		=> WP_CORE_STABLE_BRANCH,
+			'zip_size_mb' 	=> WP_CORE_ZIP_SIZE,
+			'targz_url' 	=> WP_CORE_TAR_URL,
+			'zip_url' 		=> WP_CORE_ZIP_URL,
+			'tar_size_mb' 	=> WP_CORE_TAR_SIZE
+		);
+
 	}
 
 	public function get_releases_breakdown() {


### PR DESCRIPTION
Patch adds those as constants so it's easy to adjust
