### PR TITLE
Add '--allow-root' to WP CLI commands

### DIFF
--- a/jobs.wordpressnet.dev/provision/vvv-init.sh
+++ b/jobs.wordpressnet.dev/provision/vvv-init.sh
@@ -18,13 +18,13 @@ if [ ! -d $SITE_DIR ]; then
 	mkdir $SITE_DIR/wp-content/mu-plugins
 	cp $PROVISION_DIR/wp-config.php             $SITE_DIR
 	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
-	wp plugin install si-contact-form --path=$SITE_DIR/wordpress
+	wp plugin install si-contact-form --path=$SITE_DIR/wordpress --allow-root
 
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
 
 	svn up $SITE_DIR/wordpress
 	svn up $SITE_DIR/wp-content
-	wp plugin update --all --path=$SITE_DIR/wordpress
+	wp plugin update --all --path=$SITE_DIR/wordpress --allow-root
 
 fi

--- a/wordcamp.dev/provision/vvv-init.sh
+++ b/wordcamp.dev/provision/vvv-init.sh
@@ -15,7 +15,7 @@ if [ ! -d $SITE_DIR ]; then
 	wme_import_database "wordcamp_dev" $PROVISION_DIR
 
 	# Setup WordPress
-	wp core download --path=$SITE_DIR/wordpress
+	wp core download --path=$SITE_DIR/wordpress --allow-root
 	cp $PROVISION_DIR/wp-config.php $SITE_DIR
 
 	# Check out WordCamp.org source code
@@ -36,7 +36,7 @@ if [ ! -d $SITE_DIR ]; then
 	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/wp-content/mu-plugins/
 
 	# Install 3rd-party plugins
-	wp plugin install $WPCLI_PLUGINS --path=$SITE_DIR/wordpress
+	wp plugin install $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 
 
 else
@@ -47,7 +47,7 @@ else
 	svn up $SITE_DIR/wp-content/plugins/email-post-changes
 	svn up $SITE_DIR/wp-content/plugins/tagregator
 	git -C $SITE_DIR/wp-content/plugins/camptix pull origin master
-	wp core   update --path=$SITE_DIR/wordpress
-	wp plugin update $WPCLI_PLUGINS --path=$SITE_DIR/wordpress
+	wp core   update --path=$SITE_DIR/wordpress --allow-root
+	wp plugin update $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 
 fi

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -32,7 +32,7 @@ if [ ! -d $SITE_DIR ]; then
 	svn propset svn:externals -F $PROVISION_DIR/svn-externals.tmp $SITE_DIR/wp-content/plugins
 	svn up $SITE_DIR/wp-content/plugins
 	rm -f $PROVISION_DIR/svn-externals.tmp
-	wp plugin install $WPCLI_PLUGINS --path=$SITE_DIR/wordpress
+	wp plugin install $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 
 	# developer.wordpressorg.dev
 	composer create-project rmccue/wp-parser:dev-master $SITE_DIR/wp-content/plugins/wp-parser --no-dev --keep-vcs
@@ -55,7 +55,7 @@ else
 
 	svn up $SITE_DIR/wordpress
 	svn up $SITE_DIR/wp-content
-	wp plugin update $WPCLI_PLUGINS --path=$SITE_DIR/wordpress
+	wp plugin update $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 
 	for i in "${SVN_PLUGINS[@]}"
 	do :

--- a/wordpresstv.dev/provision/vvv-init.sh
+++ b/wordpresstv.dev/provision/vvv-init.sh
@@ -19,7 +19,7 @@ if [ ! -d $SITE_DIR ]; then
 	mkdir $SITE_DIR/content/plugins
 	cp $PROVISION_DIR/wp-config.php             $SITE_DIR
 	cp $PROVISION_DIR/sandbox-functionality.php $SITE_DIR/content/mu-plugins/
-	wp plugin install jetpack --path=$SITE_DIR/wordpress
+	wp plugin install jetpack --path=$SITE_DIR/wordpress --allow-root
 
 
 else
@@ -27,6 +27,6 @@ else
 
 	svn up $SITE_DIR/wordpress
 	svn up $SITE_DIR/content
-	wp plugin update --all --path=$SITE_DIR/wordpress
+	wp plugin update --all --path=$SITE_DIR/wordpress --allow-root
 
 fi


### PR DESCRIPTION
--allow-root is needed due to the fact that the commands are called by the root user.
