### PR TITLE
BuddyPress: Update only explicitly listed plugins

### DIFF
--- a/buddypressorg.dev/provision/vvv-init.sh
+++ b/buddypressorg.dev/provision/vvv-init.sh
@@ -30,7 +30,7 @@ else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
 
 	wp core   update --path=$SITE_DIR/wordpress --allow-root
-	wp plugin update --path=$SITE_DIR/wordpress --allow-root --all
+	wp plugin update $WPCLI_PLUGINS --path=$SITE_DIR/wordpress --allow-root
 	svn up $SITE_DIR/wp-content
 	svn up $SITE_DIR/wp-content/plugins/buddypress
 	svn up $SITE_DIR/wp-content/plugins/bbpress


### PR DESCRIPTION
When re-provisioning BuddyPress tagged release `2.3.2.1` was overwriting the SVN `/trunk` checkout which is only `2.3.2`