### PR TITLE
WordPressorg.dev: Add `function_exists()` to added functions.

### DIFF
--- a/helper-functions.sh
+++ b/helper-functions.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 # Download the global WordPress.org header into the given directory and insert `wp_head()`
+# and `gp_head()`.
 #
 # This is a workaround because the header isn't open-sourced yet
 #
 # $1 - the absolute path to the folder where the header should be placed
 function wme_pull_wporg_global_header {
 	curl -o $1/header.php https://wordpress.org/header.php
-	sed -i 's/<\/head>/\n<?php wp_head(); ?>\n\n&/' $1/header.php
+	sed -i "s/<\/head>/\n<?php\nif ( function_exists( 'wp_head' ) ) {\n\twp_head();\n}\nif ( function_exists( 'gp_head' ) ) {\n\tgp_head();\n}\n?>\n\n&/" $1/header.php
 }
 
 # Download the global WordPress.org footer into the given directory and insert `wp_footer()`
@@ -17,7 +18,7 @@ function wme_pull_wporg_global_header {
 # $1 - the absolute path to the folder where the footer should be placed
 function wme_pull_wporg_global_footer {
 	curl -o $1/footer.php https://wordpress.org/footer.php
-	sed -i 's/<\/body>/\n<?php wp_footer(); ?>\n\n&/' $1/footer.php
+	sed -i "s/<\/body>/\n<?php\nif ( function_exists( 'wp_footer' ) ) {\n\twp_footer();\n}\n?>\n\n&/" $1/footer.php
 }
 
 # Create log stubs


### PR DESCRIPTION
`wp_head()` and `wp_footer()` are only available in a WordPress environment. Because the file is shared with other systems like GlotPress we have to check for their existence.

Also add `gp_head()` as a preparation for the upcoming translate.wordpressorg.dev project.