### PR TITLE
Add translate.wordpress.org

### DIFF
--- a/wordpressorg.dev/provision/gp-config.php
+++ b/wordpressorg.dev/provision/gp-config.php
@@ -1,0 +1,44 @@
+<?php
+
+$gp_table_prefix = 'translate_';
+
+define( 'WPORGPATH',             dirname( dirname( __FILE__ ) ) . '/' );
+define( 'WPORG_SANDBOXED',       true );
+
+define( 'GPDB_NAME',             'wordpressorg_dev' );
+define( 'GPDB_USER',             'wp' );
+define( 'GPDB_PASSWORD',         'wp' );
+define( 'GPDB_HOST',             'localhost' );
+define( 'GPDB_CHARSET',          'utf8' );
+define( 'GPDB_COLLATE',          '' );
+
+define( 'GP_AUTH_KEY',           'B<=-9r`TXvVa^Y0Y~8JnDye<H~@t3,k:<%My:QtMU|1pH(:7B76f:%O{AqGOMwhj' );
+define( 'GP_SECURE_AUTH_KEY',    '#vZ4tX7{67*.m]kh h[H .by&YAWrGs`Z%6;tyJ-1(@2KKxz6;>VQa^:/$%?9+_?' );
+define( 'GP_LOGGED_IN_KEY',      '5C:-K3>z,?K#CQ +A$7!]$;1A{gBiX+-DZzY()2a>;=g+zQ#@.5aYwR-.r73-r+3' );
+define( 'GP_NONCE_KEY',          'Npa lMe_;9u`DAAf_c7qnJdev#u|4g|bI^qmSFkJ*hXt,evt_rV0~C+)kM|{U3_T' );
+define( 'GP_AUTH_SALT',          'q -~]?|>qe:`:uV(ulnJ<bBVy[|@B<DkdRwhx%tWSfGyBrK.d[SvF2Rk(C=R){RI' );
+define( 'GP_SECURE_AUTH_SALT',   '+-,PoVE8!`#?O@Sv`X:Fhy~BzDt]{7}01o9#[_6tv#mLk5e}O[{[=uPZvwT[;V6^' );
+define( 'GP_LOGGED_IN_SALT',     '-O8.ClBi]awaLi$!c>3 L(:+Yi)L/fZ|m3DRyu1e-SYM`q2JZsG@zU|VtZBEqCH<' );
+define( 'GP_NONCE_SALT',         '|mk?Ht,|+:hQ&(+rb&uOxL*bIY&EL]M<@v-?dbxf!PB;&+3A4-/H.2~<q!69X.]|' );
+
+define( 'GP_COOKIE_DOMAIN',      '.wordpressorg.dev' );
+
+define( 'GP_AUTH_COOKIE',        'wporgdev' );
+define( 'GP_SECURE_AUTH_COOKIE', 'wporgdev_sec' );
+define( 'GP_LOGGED_IN_COOKIE',   'wporgdev_logged_in' );
+
+define( 'GP_DEBUG',              true );
+
+define( 'GP_PLUGINS_PATH',       __DIR__ . '/gp-plugins/' );
+define( 'GP_TMPL_PATH',          __DIR__ . '/gp-templates/' );
+
+/**
+ * Custom users and usermeta tables for integration with WordPress user system.
+ *
+ * You might want to delete your current permissions, since they will point to different
+ * users in the custom table. You can use `php scripts/wipe-permissions.php` for that.
+ *
+ * If you start with fresh permissions, you can add admins via `php scripts/add-admin.php`
+ */
+// define('CUSTOM_USER_TABLE', 'wp_users');
+// define('CUSTOM_USER_META_TABLE', 'wp_usermeta');

--- a/wordpressorg.dev/provision/gp-config.php
+++ b/wordpressorg.dev/provision/gp-config.php
@@ -32,13 +32,8 @@ define( 'GP_DEBUG',              true );
 define( 'GP_PLUGINS_PATH',       __DIR__ . '/gp-plugins/' );
 define( 'GP_TMPL_PATH',          __DIR__ . '/gp-templates/' );
 
-/**
- * Custom users and usermeta tables for integration with WordPress user system.
- *
- * You might want to delete your current permissions, since they will point to different
- * users in the custom table. You can use `php scripts/wipe-permissions.php` for that.
- *
- * If you start with fresh permissions, you can add admins via `php scripts/add-admin.php`
- */
-// define('CUSTOM_USER_TABLE', 'wp_users');
-// define('CUSTOM_USER_META_TABLE', 'wp_usermeta');
+define( 'GP_URL',                'http://translate.wordpressorg.dev/' );
+define( 'GP_BASE_URL',           'http://translate.wordpressorg.dev/glotpress/' );
+
+define( 'CUSTOM_USER_TABLE',      'wporg_users' );
+define( 'CUSTOM_USER_META_TABLE', 'wporg_usermeta' );

--- a/wordpressorg.dev/provision/vvv-hosts
+++ b/wordpressorg.dev/provision/vvv-hosts
@@ -3,6 +3,7 @@ wordpressorg.dev
 make.wordpressorg.dev
 learn.wordpressorg.dev
 developer.wordpressorg.dev
+translate.wordpressorg.dev
 global.wordpressorg.dev
 	en.wordpressorg.dev
 	es.wordpressorg.dev

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -55,6 +55,12 @@ if [ ! -d $SITE_DIR ]; then
 	wget https://translate.wordpress.org/projects/meta/themes/es/default/export-translations?format=mo -O $SITE_DIR/wp-content/languages/themes/wporg-themes-es_ES.mo
 	wget https://translate.wordpress.org/projects/meta/themes/es/default/export-translations?format=po -O $SITE_DIR/wp-content/languages/themes/wporg-themes-es_ES.po
 
+	# translate.wordpressorg.dev
+	mkdir $SITE_DIR/translate
+	svn co https://glotpress.svn.wordpress.org/trunk $SITE_DIR/translate/glotpress
+	svn co https://meta.svn.wordpress.org/sites/trunk/translate.wordpress.org/includes/gp-plugins $SITE_DIR/translate/gp-plugins/
+	svn co https://meta.svn.wordpress.org/sites/trunk/translate.wordpress.org/public_html/gp-templates $SITE_DIR/translate/gp-templates/
+
 else
 	printf "\n#\n# Updating $SITE_DOMAIN\n#\n"
 
@@ -66,6 +72,11 @@ else
 	do :
 		svn up $SITE_DIR/wp-content/plugins/$i
 	done
+
+	# translate.wordpressorg.dev
+	svn up $SITE_DIR/translate/glotpress
+	svn up $SITE_DIR/translate/gp-plugins
+	svn up $SITE_DIR/translate/gp-templates
 
 	# developer.wordpressorg.dev
 	# composer update rmccue/wp-parser # todo no composer.json file

--- a/wordpressorg.dev/provision/vvv-nginx.conf
+++ b/wordpressorg.dev/provision/vvv-nginx.conf
@@ -1,6 +1,38 @@
 server {
 	listen       80;
 	listen       443 ssl;
+	server_name  translate.wordpressorg.dev;
+	root         /srv/www/wordpress-meta-environment/wordpressorg.dev/public_html/translate;
+	access_log   /srv/www/wordpress-meta-environment/wordpressorg.dev/logs/nginx-access.log;
+	error_log    /srv/www/wordpress-meta-environment/wordpressorg.dev/logs/nginx-error.log;
+
+	charset utf-8;
+	gzip off;
+
+	location = / {
+		rewrite ^ /glotpress/index.php last;
+	}
+
+	location / {
+		try_files $uri $uri/ /glotpress/index.php$is_args$args;
+	}
+
+	location ~ \.php$ {
+		# Extracted from /etc/nginx/nginx-wp-common.conf
+		try_files            $uri =404;
+		include              /etc/nginx/fastcgi_params;
+		fastcgi_read_timeout 3600s;
+		fastcgi_buffer_size  128k;
+		fastcgi_buffers      4 128k;
+		fastcgi_param        SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_pass         php;
+		fastcgi_index        index.php;
+	}
+}
+
+server {
+	listen       80;
+	listen       443 ssl;
 	server_name  wordpressorg.dev *.wordpressorg.dev;
 	root         /srv/www/wordpress-meta-environment/wordpressorg.dev/public_html/wordpress;
 	access_log   /srv/www/wordpress-meta-environment/wordpressorg.dev/logs/nginx-access.log;

--- a/wp-meta.dev/public_html/index.php
+++ b/wp-meta.dev/public_html/index.php
@@ -10,12 +10,12 @@
 <body>
 
 	<h1>WordPress Meta Environment</h1>
-	
+
 	<p>
 		All of the sites listed below have been provisioned into your local development environment. You can log in
 		to any of them with username <code>admin</code> and password <code>password</code>.
 	</p>
-	
+
 	<h2>Available Sites</h2>
 
 	<p>The hostname for each site has been slightly changed. For example, <code>wordcamp.org</code> and <code>wordpress.tv</code> are <code>wordcamp.dev</code> and <code>wordpresstv.dev</code>, respectively.</p>
@@ -47,6 +47,7 @@
 			<ul>
 				<li><a href="http://apps.wordpressorg.dev">apps.wordpressorg.dev</a></li>
 				<li><a href="http://developer.wordpressorg.dev">developer.wordpressorg.dev</a></li>
+				<li><a href="http://translate.wordpressorg.dev">translate.wordpressorg.dev</a></li>
 
 				<li>
 					<a href="http://global.wordpressorg.dev">global.wordpressorg.dev</a>
@@ -60,7 +61,7 @@
 		</li>
 		<li><a href="http://wordpresstv.dev">wordpresstv.dev</a></li>
 	</ul>
-	
+
 	<h2>Resources</h2>
 	<ul>
 		<li><a href="https://github.com/iandunn/wordpress-meta-environment">WME homepage</a></li>


### PR DESCRIPTION
This pull request brings translate.wordpress.org as translate.wordpressorg.dev to WME.

__todo__:

- [x] Add `gp-config.php`
- [x] Update hosts file
- [x] Update nginx config
- [x] Update provision script
- [x] Update database dump
- [x] Fix cookie names #19
- [x] Fix global header #20
- [x] Move to its own root #26 