### PR TITLE
WordPressorg.dev: Add config for memcached server and memcached drop-in.

### DIFF
--- a/wordpressorg.dev/provision/memcached-wordpressorg.conf
+++ b/wordpressorg.dev/provision/memcached-wordpressorg.conf
@@ -1,0 +1,51 @@
+# memcached-wordpressorg.conf
+#
+# Varying Vagrant Vagrant's modification of the default memcached config for
+# WordPressorg.dev.
+#
+# Original config - 2003 - Jay Bonci <jaybonci@debian.org>
+# This configuration file is read by the start-memcached script provided as
+# part of the Debian GNU/Linux distribution.
+
+# Run memcached as a daemon. This command is implied, and is not needed for the
+# daemon to run. See the README.Debian that comes with this package for more
+# information.
+-d
+
+# Log memcached's output to /var/log/memcached
+logfile /var/log/memcached-wordpressorg.log
+
+# Be verbose
+# -v
+
+# Be even more verbose (print client commands as well)
+# -vv
+
+# Memcached starts with a 64M cap by default. We replace with 128M to aid in testing
+# large sites that like the space.
+-m 128
+
+# Default connection port is 11211
+-p 11212
+
+# Run the daemon as root. The start-memcached will default to running as root if no
+# -u command is present in this config file
+-u memcache
+
+# Specify which IP address to listen on. The default is to listen on all IP addresses
+# This parameter is one of the only security measures that memcached has, so make sure
+# it's listening on a firewalled interface. Note that 192.168.50.4 is the private
+# network IP for the Vagrant box per the Vagrantfile, and as such, it is safe.
+-l 127.0.0.1,192.168.50.4
+
+# Limit the number of simultaneous incoming connections. The daemon default is 1024
+# -c 1024
+
+# Lock down all paged memory. Consult with the README and homepage before you do this
+# -k
+
+# Return error when memory is exhausted (rather than removing items)
+# -M
+
+# Maximize core file limit
+# -r

--- a/wordpressorg.dev/provision/vvv-init.sh
+++ b/wordpressorg.dev/provision/vvv-init.sh
@@ -96,6 +96,11 @@ if [ ! -L $SITE_DIR ]; then
 	cp "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
 	service cavalcade-wordpressorg restart
 
+	# Memcached
+	curl -sfg -o "$SITE_DIR/wp-content/object-cache.php" https://plugins.svn.wordpress.org/memcached/trunk/object-cache.php || echo "Error downloading object-cache.php"
+	cp "$PROVISION_DIR/memcached-wordpressorg.conf" "/etc/memcached-wordpressorg.conf"
+	service memcached restart wordpressorg
+
 	# Ignore external dependencies and Meta Environment tweaks
 	IGNORED_FILES=(
 		/wordpress
@@ -109,6 +114,7 @@ if [ ! -L $SITE_DIR ]; then
 		/wp-content/themes/rosetta
 		/wp-content/themes/twenty*
 		/wp-content/sunrise.php
+		/wp-content/object-cache.php
 		/footer.php
 		/header.php
 		/wp-config.php
@@ -156,6 +162,11 @@ else
 	cp "$PROVISION_DIR/cavalcade.php" "$SITE_DIR/wp-content/mu-plugins/"
 	cp "$PROVISION_DIR/cavalcade-wordpressorg.conf" "/etc/init/cavalcade-wordpressorg.conf"
 	service cavalcade-wordpressorg restart
+
+	# Memcached
+	curl -sfg -o "$SITE_DIR/wp-content/object-cache.php" https://plugins.svn.wordpress.org/memcached/trunk/object-cache.php || echo "Error downloading object-cache.php"
+	cp "$PROVISION_DIR/memcached-wordpressorg.conf" "/etc/memcached-wordpressorg.conf"
+	service memcached restart wordpressorg
 fi
 
 # Pull global header/footer

--- a/wordpressorg.dev/provision/wp-config.php
+++ b/wordpressorg.dev/provision/wp-config.php
@@ -62,6 +62,12 @@ define( 'DISABLE_WP_CRON', true );
 define( 'GLOTPRESS_LOCALES_PATH', dirname( dirname( dirname( __DIR__ ) ) ) . '/meta-repository/wordpress.org/public_html/wp-content/plugins/glotpress/locales/locales.php' );
 define( 'GLOTPRESS_TABLE_PREFIX', 'translate_' );
 
+$memcached_servers = array(
+	'default' => array(
+		'127.0.0.1:11212',
+	),
+);
+
 if ( $_SERVER['HTTP_HOST'] === 'make.wordpressorg.dev' ) {
 	define( 'DOMAIN_CURRENT_SITE',  'make.wordpressorg.dev' );
 	define( 'PATH_CURRENT_SITE',    '/' );


### PR DESCRIPTION
Creates a new memcached server running on port 11212 that is used by the WordPress.org network install.

Fixes #109.